### PR TITLE
Remove heroku gem dependency

### DIFF
--- a/jekyll-auth.gemspec
+++ b/jekyll-auth.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency("sinatra-index")
   s.add_dependency("sinatra_auth_github")
   s.add_dependency("commander")
-  s.add_dependency("heroku")
   s.add_dependency("git")
   s.add_dependency("dotenv")
   s.add_dependency("rake")


### PR DESCRIPTION
gem has been deprecated in lieu of the toolbelt
https://blog.heroku.com/archives/2012/10/15/upgrading-to-the-heroku-toolbelt
