### PR TITLE
Space between hashbang and path to interpreter -- read otherwise as Racket?

### DIFF
--- a/script/server
+++ b/script/server
@@ -1,3 +1,3 @@
-#!/bin/sh
+#! /bin/sh
 
 bundle exec jekyll-auth


### PR DESCRIPTION
github/linguist is weird.

This is entirely cosmetic and can be closed at your leisure.
