### PR TITLE
GitHub oauth scope: read:org

### DIFF
--- a/lib/jekyll-auth/auth-site.rb
+++ b/lib/jekyll-auth/auth-site.rb
@@ -15,7 +15,7 @@ class JekyllAuth
     set :github_options, {
       :client_id     => ENV['GITHUB_CLIENT_ID'],
       :client_secret => ENV['GITHUB_CLIENT_SECRET'],
-      :scopes        => 'user'
+      :scopes        => 'read:org'
     }
 
     register Sinatra::Auth::Github


### PR DESCRIPTION
If I understand [scopes](https://developer.github.com/v3/oauth/#scopes) correctly, the current `user` scope has unneeded write privileges.

`read:org` is all we need.
