### PR TITLE
Support verified session cookies by default

### DIFF
--- a/jekyll-auth.gemspec
+++ b/jekyll-auth.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("jekyll", "~> 2.0")
   s.add_dependency("sinatra-index", "~> 0.0")
-  s.add_dependency("sinatra_auth_github", "~> 1.0")
+  s.add_dependency("sinatra_auth_github", "~> 1.1")
   s.add_dependency("commander", "~> 4.1")
   s.add_dependency("git", "~> 1.2")
   s.add_dependency("dotenv", "~> 0.11")

--- a/lib/jekyll-auth/version.rb
+++ b/lib/jekyll-auth/version.rb
@@ -1,3 +1,3 @@
 class JekyllAuth
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
This ensures that users of the sinatra_auth_github gem aren't accidentally exposing github oauth tokens that are marshalled into their sessions. If this is used in a multi-process or multi-dyno setup then you'll need to set a common environmental variable, `WARDEN_GITHUB_VERIFIER_SECRET`.

/cc https://github.com/atmos/warden-github/pull/43