### PR TITLE
Serve custom 404

### DIFF
--- a/lib/jekyll_auth/jekyll_site.rb
+++ b/lib/jekyll_auth/jekyll_site.rb
@@ -1,11 +1,6 @@
 class JekyllAuth
   class JekyllSite < Sinatra::Base
 
-
-    def four_oh_four
-      path if File.exists?(path)
-    end
-
     register Sinatra::Index
     set :public_folder, File.expand_path('_site', Dir.pwd)
     use_static_index 'index.html'

--- a/lib/jekyll_auth/jekyll_site.rb
+++ b/lib/jekyll_auth/jekyll_site.rb
@@ -1,7 +1,19 @@
 class JekyllAuth
   class JekyllSite < Sinatra::Base
+
+
+    def four_oh_four
+      path if File.exists?(path)
+    end
+
     register Sinatra::Index
     set :public_folder, File.expand_path('_site', Dir.pwd)
     use_static_index 'index.html'
+
+    not_found do
+      status 404
+      four_oh_four = File.expand_path('_site/404.html', Dir.pwd)
+      File.read(four_oh_four) if File.exists?(four_oh_four)
+    end
   end
 end

--- a/spec/jekyll_auth_jekyll_site_spec.rb
+++ b/spec/jekyll_auth_jekyll_site_spec.rb
@@ -28,4 +28,17 @@ describe "jekyll site" do
     expect(last_response.body).to eql("My awesome directory")
   end
 
+  it "serves the default 404" do
+    get "/a-bad-path"
+    expect(last_response.status).to eql(404)
+    expect(last_response.body).to eql("<h1>Not Found</h1>")
+  end
+
+  it "serves a custom 404" do
+    File.write File.expand_path("_site/404.html", tmp_dir), "My custom 404"
+    get "/a-bad-path"
+    expect(last_response.status).to eql(404)
+    expect(last_response.body).to eql("My custom 404")
+  end
+
 end


### PR DESCRIPTION
Fixes https://github.com/benbalter/jekyll-auth/issues/51.

@gjtorikian this what you had in mind? This uses Sinatra's 404 mechanism, rather than Rack directly, which will provide additional debug output in dev.