### PR TITLE
Pass along the Git SHA to the built site

### DIFF
--- a/bin/jekyll-auth
+++ b/bin/jekyll-auth
@@ -33,6 +33,23 @@ Mercenary.program("jekyll-auth") do |p|
     c.description "Build the Jekyll site"
     c.action do |args, options|
       require 'jekyll'
+
+      yaml = """
+is_jekyll_auth: true
+git_sha: #{ENV['GIT_SHA']}
+"""
+      config_jekyll_auth = Tempfile.new('_config.jekyll-auth.yml')
+
+      config_jekyll_auth.write(yaml.strip)
+      config_jekyll_auth.rewind
+      config_jekyll_auth.close
+
+      if options['config'].nil?
+        options['config'] = ['_config.yml', config_jekyll_auth.path]
+      else
+        options['config'] = options['config'].push(config_jekyll_auth.path)
+      end
+
       Jekyll::Commands::Build.process(options)
     end
   end


### PR DESCRIPTION
This is a change I've used once and see myself using again. It takes advantage of the fact that Heroku sets the `GIT_SHA` environment variable on deploy. Template writers can take advantage of this to present commit information, a la:

![screen shot 2015-03-03 at 10 45 32 pm](https://cloud.githubusercontent.com/assets/64050/6479230/0649cafa-c1f7-11e4-8045-96a60e513309.png)

I would love to write tests, but I have no idea where to place them. Seems like nothing is actually testing the execution of the Rake task?