### PR TITLE
Force host for Docker

### DIFF
--- a/bin/jekyll-auth
+++ b/bin/jekyll-auth
@@ -89,7 +89,7 @@ Mercenary.program("jekyll-auth") do |p|
 
       puts "Spinning up the server with authentication. Use CTRL-C to stop."
       puts "To preview the site without authentication, use the `jekyll serve` command"
-      JekyllAuth::Commands.execute_command "bundle", "exec", "rackup", "-p", "4000"
+      JekyllAuth::Commands.execute_command "bundle", "exec", "rackup", "--host", "0.0.0.0", "-p", "4000"
 
     end
   end


### PR DESCRIPTION
Running jekyl-auth in a docker container, I need to force the actual host in order to be able to access the server externally