### PR TITLE
Sets default values for GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET in test mode

### DIFF
--- a/lib/jekyll_auth/commands.rb
+++ b/lib/jekyll_auth/commands.rb
@@ -1,7 +1,7 @@
 class JekyllAuth
   class Commands
-    FILES = %w(Rakefile config.ru .gitignore .env)
-    VARS  = %w(client_id client_secret team_id org_name)
+    FILES = %w(Rakefile config.ru .gitignore .env).freeze
+    VARS  = %w(client_id client_secret team_id org_name).freeze
 
     def self.source
       @source ||= File.expand_path('../../templates', File.dirname(__FILE__))
@@ -43,7 +43,7 @@ class JekyllAuth
     end
 
     def self.env_var_set?(var)
-      !(ENV[var].to_s.blank?)
+      !ENV[var].to_s.blank?
     end
 
     def self.init_repo

--- a/lib/jekyll_auth/version.rb
+++ b/lib/jekyll_auth/version.rb
@@ -1,3 +1,3 @@
 class JekyllAuth
-  VERSION = '2.0.0'
+  VERSION = '2.0.0'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,8 @@ def execute_bin(env, *args)
 end
 
 Dotenv.load
+ENV['GITHUB_CLIENT_ID'] ||= 'IGNORE'
+ENV['GITHUB_CLIENT_SECRET'] ||= 'IGNORE'
 setup_tmp_dir
 
 require_relative '../lib/jekyll-auth'


### PR DESCRIPTION
rake failed after a clean checkout - specifically jekyl_auth_auth_site_spec.rb
This commit conditionally sets default values for the GitHub client env vars
if they've not been set already.