### PR TITLE
Adds team-based whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ jekyll_auth:
     - "^((?!draft).)*$"
 ```
 
+And if you want to make parts of the site available to specific teams, you can create a whitelist entry for each team:
+
+```yaml
+jekyll_auth:
+  team_1234:
+    - drafts?
+```
+
 There is also a more [extensive article containing installation instructions for Jekyll-Auth](http://fabian-kostadinov.github.io/2014/11/13/installation-of-jekyll-auth/) and a second one on [how to find your GitHub team ID](http://fabian-kostadinov.github.io/2015/01/16/how-to-find-a-github-team-id/).
 
 ### Requiring SSL

--- a/lib/jekyll-auth.rb
+++ b/lib/jekyll-auth.rb
@@ -11,6 +11,7 @@ require_relative 'jekyll_auth/auth_site'
 require_relative 'jekyll_auth/jekyll_site'
 require_relative 'jekyll_auth/config_error'
 require_relative 'jekyll_auth/commands'
+require_relative 'jekyll_auth/sinatra/auth/github'
 
 Dotenv.load
 

--- a/lib/jekyll_auth/auth_site.rb
+++ b/lib/jekyll_auth/auth_site.rb
@@ -27,6 +27,8 @@ class JekyllAuth
         github_team_authenticate! ENV['GITHUB_TEAM_ID']
       when :teams
         github_teams_authenticate! ENV['GITHUB_TEAM_IDS'].split(',')
+      when :teams_fine
+        fine_teams_authenticate! JekyllAuth.whitelist_teams
       when :org
         github_organization_authenticate! ENV['GITHUB_ORG_NAME']
       else

--- a/lib/jekyll_auth/config.rb
+++ b/lib/jekyll_auth/config.rb
@@ -19,11 +19,10 @@ class JekyllAuth
 
   def self.whitelist_teams
     JekyllAuth.config
-      .select {|k,_| k =~ /^team_\d+$/ }
-      .inject({}) {|h, (k, whitelist)|
-        h[k.sub('team_', '')] = Regexp.new(whitelist.join('|'))
-        h
-      }
+              .select { |k, _| k =~ /^team_\d+$/ }
+              .each_with_object({}) do |(k, whitelist), hash|
+                hash[k.sub('team_', '')] = Regexp.new(whitelist.join('|'))
+              end
   end
 
   def self.ssl?

--- a/lib/jekyll_auth/config.rb
+++ b/lib/jekyll_auth/config.rb
@@ -17,6 +17,15 @@ class JekyllAuth
     Regexp.new(whitelist.join('|')) unless whitelist.nil?
   end
 
+  def self.whitelist_teams
+    JekyllAuth.config
+      .select {|k,_| k =~ /^team_\d+$/ }
+      .inject({}) {|h, (k, whitelist)|
+        h[k.sub('team_', '')] = Regexp.new(whitelist.join('|'))
+        h
+      }
+  end
+
   def self.ssl?
     !!JekyllAuth.config['ssl']
   end

--- a/lib/jekyll_auth/helpers.rb
+++ b/lib/jekyll_auth/helpers.rb
@@ -6,7 +6,9 @@ class JekyllAuth
     end
 
     def authentication_strategy
-      if !ENV['GITHUB_TEAM_ID'].to_s.blank?
+      if JekyllAuth.whitelist_teams.any?
+        :teams_fine
+      elsif !ENV['GITHUB_TEAM_ID'].to_s.blank?
         :team
       elsif !ENV['GITHUB_TEAM_IDS'].to_s.blank?
         :teams

--- a/lib/jekyll_auth/sinatra/auth/github.rb
+++ b/lib/jekyll_auth/sinatra/auth/github.rb
@@ -10,8 +10,9 @@ module Sinatra
 
         def fine_teams_authenticate!(team_whitelists)
           authenticate!
-          halt([401, 'Unauthorized User']) unless team_whitelists
-            .any? { |team_id, whitelist| github_team_access?(team_id) && whitelist.match(request.path_info) }
+          unless team_whitelists.any? { |team_id, whitelist| github_team_access?(team_id) && whitelist.match(request.path_info) }
+            halt([401, 'Unauthorized User'])
+          end
         end
       end
     end

--- a/lib/jekyll_auth/sinatra/auth/github.rb
+++ b/lib/jekyll_auth/sinatra/auth/github.rb
@@ -7,6 +7,12 @@ module Sinatra
           authenticate!
           halt([401, 'Unauthorized User']) unless teams.any? { |team_id| github_team_access?(team_id) }
         end
+
+        def fine_teams_authenticate!(team_whitelists)
+          authenticate!
+          halt([401, 'Unauthorized User']) unless team_whitelists
+            .any? { |team_id, whitelist| github_team_access?(team_id) && whitelist.match(request.path_info) }
+        end
       end
     end
   end

--- a/lib/jekyll_auth/sinatra/auth/github.rb
+++ b/lib/jekyll_auth/sinatra/auth/github.rb
@@ -1,10 +1,12 @@
 module Sinatra
   module Auth
     module Github
-      # Like the native github_team_authenticate! but accepts an array of team ids
-      def github_teams_authenticate!(teams)
-        authenticate!
-        halt([401, 'Unauthorized User']) unless teams.any? { |team_id| github_team_access?(team_id) }
+      module Helpers
+        # Like the native github_team_authenticate! but accepts an array of team ids
+        def github_teams_authenticate!(teams)
+          authenticate!
+          halt([401, 'Unauthorized User']) unless teams.any? { |team_id| github_team_access?(team_id) }
+        end
       end
     end
   end

--- a/spec/jekyll_auth_auth_site_spec.rb
+++ b/spec/jekyll_auth_auth_site_spec.rb
@@ -8,7 +8,6 @@ describe 'logged in user' do
   end
 
   before(:each) do
-    setup_tmp_dir
     @user = make_user('login' => 'benbaltertest')
     login_as @user
 
@@ -71,7 +70,6 @@ describe 'logged out user' do
   end
 
   before do
-    setup_tmp_dir
     ENV['GITHUB_ORG_NAME'] = 'balter-test-org'
   end
 

--- a/spec/jekyll_auth_auth_site_spec.rb
+++ b/spec/jekyll_auth_auth_site_spec.rb
@@ -34,14 +34,14 @@ describe 'logged in user' do
 
   context 'fine-grained team access' do
     before do
-      stub_request(:get, "https://api.github.com/teams/456/members/benbaltertest")
+      stub_request(:get, 'https://api.github.com/teams/456/members/benbaltertest')
         .to_return(status: 204)
       File.write(JekyllAuth.config_file, "jekyll_auth:\n  team_123:\n   - index.html\n  team_456:\n   - chicken.html\n")
       `bundle exec jekyll build`
     end
 
     it 'shows a page the user has access to' do
-      stub_request(:get, "https://api.github.com/teams/123/members/benbaltertest")
+      stub_request(:get, 'https://api.github.com/teams/123/members/benbaltertest')
         .to_return(status: 204)
 
       get '/index.html'
@@ -51,7 +51,7 @@ describe 'logged in user' do
     end
 
     it 'shows the securocat for a page the user does not have access to' do
-      stub_request(:get, "https://api.github.com/teams/123/members/benbaltertest")
+      stub_request(:get, 'https://api.github.com/teams/123/members/benbaltertest')
         .to_return(status: 404)
 
       get '/index.html'

--- a/spec/jekyll_auth_bin_spec.rb
+++ b/spec/jekyll_auth_bin_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe 'bin' do
-  before(:each) do
-    setup_tmp_dir
-  end
-
   it 'spits out the help do' do
     env = { 'GITHUB_TOKEN' => nil }
     output = execute_bin(env, '--help')

--- a/spec/jekyll_auth_commands_spec.rb
+++ b/spec/jekyll_auth_commands_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe 'commands' do
-  before do
-    setup_tmp_dir
-  end
-
   it 'should find the template directory' do
     expect(File.directory?(JekyllAuth::Commands.source)).to eql(true)
     expect(File).to exist("#{JekyllAuth::Commands.source}/config.ru")

--- a/spec/jekyll_auth_helpers_spec.rb
+++ b/spec/jekyll_auth_helpers_spec.rb
@@ -43,6 +43,18 @@ describe 'strategies' do
     end
   end
 
+  it 'should detect the teams_fine strategy (and take precedence over other strategies)' do
+    File.write(JekyllAuth.config_file, "jekyll_auth:\n  team_123:\n   - drafts?\n")
+
+    with_env('GITHUB_ORG_NAME', 'some_org') do
+      with_env('GITHUB_TEAM_ID', '1234') do
+        with_env('GITHUB_TEAM_IDS', '1234,5678') do
+          expect(@helper.authentication_strategy).to eql(:teams_fine)
+        end
+      end
+    end
+  end
+
   it 'should know if a path is whitelisted' do
     File.write(JekyllAuth.config_file, "jekyll_auth:\n  whitelist:\n   - drafts?\n")
 

--- a/spec/jekyll_auth_jekyll_site_spec.rb
+++ b/spec/jekyll_auth_jekyll_site_spec.rb
@@ -8,7 +8,6 @@ describe 'jekyll site' do
   end
 
   before do
-    setup_tmp_dir
     File.write File.expand_path('_config.yml', tmp_dir), 'foo: bar'
     `bundle exec jekyll build`
   end

--- a/spec/jekyll_auth_spec.rb
+++ b/spec/jekyll_auth_spec.rb
@@ -43,4 +43,10 @@ describe 'JekyllAuth' do
     File.write(JekyllAuth.config_file, "jekyll_auth:\n  whitelist:\n   - drafts?\n")
     expect(JekyllAuth.whitelist).to eql(/drafts?/)
   end
+
+  it 'should parse the teams' do
+    File.write(JekyllAuth.config_file, "jekyll_auth:\n  team_123:\n   - drafts?\n  team_456:\n   - chicken?\n")
+    expect(JekyllAuth.whitelist_teams['123']).to eql(/drafts?/)
+    expect(JekyllAuth.whitelist_teams['456']).to eql(/chicken?/)
+  end
 end

--- a/spec/jekyll_auth_spec.rb
+++ b/spec/jekyll_auth_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe 'JekyllAuth' do
   before(:each) do
-    setup_tmp_dir
     JekyllAuth.instance_variable_set('@config', nil)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,4 +59,5 @@ WebMock.disable_net_connect!
 
 RSpec.configure do |config|
   config.include(Sinatra::Auth::Github::Test::Helper)
+  config.before { JekyllAuth.instance_variable_set(:@config, nil) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,7 +62,7 @@ RSpec.configure do |config|
 
   config.before do
     JekyllAuth.instance_variable_set(:@config, nil)
-    %w(GITHUB_ORG_NAME GITHUB_TEAM_ID GITHUB_TEAM_ID).each {|v| ENV.delete(v) }
+    %w(GITHUB_ORG_NAME GITHUB_TEAM_ID GITHUB_TEAM_ID).each { |v| ENV.delete(v) }
     setup_tmp_dir
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,5 +59,10 @@ WebMock.disable_net_connect!
 
 RSpec.configure do |config|
   config.include(Sinatra::Auth::Github::Test::Helper)
-  config.before { JekyllAuth.instance_variable_set(:@config, nil) }
+
+  config.before do
+    JekyllAuth.instance_variable_set(:@config, nil)
+    %w(GITHUB_ORG_NAME GITHUB_TEAM_ID GITHUB_TEAM_ID).each {|v| ENV.delete(v) }
+    setup_tmp_dir
+  end
 end


### PR DESCRIPTION
You can restrict parts of the site to a specific team using a new kind of key in the jekyll config:

``` yaml
jekyll_auth:
  team_1234:
    - drafts?
```

This is my take on the first part of #76 
