### PR TITLE
Uses the jekyll _config.yml file to determine the webroot path

### DIFF
--- a/lib/jekyll_auth/config.rb
+++ b/lib/jekyll_auth/config.rb
@@ -3,21 +3,36 @@ class JekyllAuth
     File.join(Dir.pwd, '_config.yml')
   end
 
+  def self.jekyll_config
+    @config ||= begin
+      jekyll_config = YAML.safe_load_file(config_file)
+    rescue
+      {}
+    end
+  end
+
+  def self.destination
+    @config ||= begin
+      JekyllAuth.jekyll_config['destination'] || '_site'
+    rescue
+      {}
+    end
+  end
+
   def self.config
     @config ||= begin
-      config = YAML.safe_load_file(config_file)
-      config['jekyll_auth'] || {}
+      JekyllAuth.jekyll_config['jekyll_auth'] || {}
     rescue
       {}
     end
   end
 
   def self.whitelist
-    whitelist = JekyllAuth.config['whitelist']
+    whitelist = JekyllAuth.jekyll_config['whitelist']
     Regexp.new(whitelist.join('|')) unless whitelist.nil?
   end
 
   def self.ssl?
-    !!JekyllAuth.config['ssl']
+    !!JekyllAuth.jekyll_config['ssl']
   end
 end

--- a/lib/jekyll_auth/jekyll_site.rb
+++ b/lib/jekyll_auth/jekyll_site.rb
@@ -1,12 +1,12 @@
 class JekyllAuth
   class JekyllSite < Sinatra::Base
     register Sinatra::Index
-    set :public_folder, File.expand_path('_site', Dir.pwd)
+    set :public_folder, File.expand_path(JekyllAuth.destination, Dir.pwd)
     use_static_index 'index.html'
 
     not_found do
       status 404
-      four_oh_four = File.expand_path('_site/404.html', Dir.pwd)
+      four_oh_four = File.expand_path(settings.public_folder + '/404.html', Dir.pwd)
       File.read(four_oh_four) if File.exist?(four_oh_four)
     end
   end


### PR DESCRIPTION
Currently jekyll-auth assumes that the webroot is always _site. If the destination is specified in _config.yml it should be respected.

Note: this is revised from my original PR due to some failures of my coffee this morning. 
