### PR TITLE
Updates colorator dependency for Jekyll ~> 3.2.0 compatability

### DIFF
--- a/jekyll-auth.gemspec
+++ b/jekyll-auth.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-ssl-enforcer', '~> 0.2'
   s.add_dependency 'mercenary', '~> 0.3'
   s.add_dependency 'safe_yaml', '~> 1.0'
-  s.add_dependency 'colorator', '~> 0.1'
+  s.add_dependency 'colorator', '~> 1.0'
   s.add_dependency 'activesupport', '~> 4.0'
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'rack-test', '~> 0.6'


### PR DESCRIPTION
Using this with Jekyll 3.2.0 or higher will fail due to the requirement of `colorator ~> 0.1` (since Jekyll requires ~> 1.0).

This is the cause of #95.

I suppose we probably don't need it in there as a dependency at all, since Jekyll is now requiring it... ¯\\\_(ツ)_/¯