### PR TITLE
Remove /Gemfile.lock from .gitignore template

### DIFF
--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,3 +1,2 @@
 _site
 .env
-/Gemfile.lock


### PR DESCRIPTION
When `bundle exec jekyll-auth new` runs, it copies this template file to the users project. Currently this .gitignore template adds  `/Gemfile.lock` to .gitignore. Then, when the user tries to push their app to heroku, they get an error that a Gemfile.lock is required to deploy the app.

There is some confusion about this as evidenced in https://github.com/benbalter/jekyll-auth/issues/84

This commit removes /Gemfile.lock from the .gitignore template