### PR TITLE
Setup command now correctly accepts arguments

### DIFF
--- a/bin/jekyll-auth
+++ b/bin/jekyll-auth
@@ -101,10 +101,10 @@ Mercenary.program("jekyll-auth") do |p|
   p.command(:setup) do |c|
     c.syntax "setup"
     c.description "Configure Heroku for use with your Jekyll Auth site"
-    c.option "client_id", "--client_id", "Your oauth app client id"
-    c.option "client_secret", "--client_secret", "Your oauth app client secret"
-    c.option "team_id", "--team_id", "The team to authenticate against"
-    c.option "org_name", "--org_name", "An organization to authenticate against"
+    c.option "client_id", "--client_id <ID>", "Your oauth app client id"
+    c.option "client_secret", "--client_secret <SECRET>", "Your oauth app client secret"
+    c.option "team_id", "--team_id <ID>", "The team to authenticate against"
+    c.option "org_name", "--org_name <NAME>", "An organization to authenticate against"
     c.action do |_args, options|
       if find_executable("heroku").nil?
         puts "Looks like we're missing the Heroku client. Let's see if we can't install it..."

--- a/spec/jekyll_auth_bin_spec.rb
+++ b/spec/jekyll_auth_bin_spec.rb
@@ -47,7 +47,7 @@ describe "bin" do
     `git add .`
     `git commit -m 'initial commit'`
     execute_bin({ "RACK_ENV" => "TEST" }, "new")
-    execute_bin({}, "setup", "--client_id", "my_client_id", "--client_secret", "my_client_secret", "--team_id", "my_team_id", "--org_name", "my_org_name")
+    execute_bin({ "RACK_ENV" => "TEST" }, "setup", "--client_id", "my_client_id", "--client_secret", "my_client_secret", "--team_id", "my_team_id", "--org_name", "my_org_name")
     VARS  = %w(client_id client_secret team_id org_name)
     VARS.each do |var|
       expect((`heroku config:get GITHUB_#{var.upcase}`).strip).to eql("my_#{var}")

--- a/spec/jekyll_auth_bin_spec.rb
+++ b/spec/jekyll_auth_bin_spec.rb
@@ -38,25 +38,6 @@ describe "bin" do
     expect(File).to exist("#{tmp_dir}/.env")
   end
 
-  it "sets heroku config vars" do
-    `git init`
-    `touch Gemfile`
-    Bundler.with_clean_env {
-      `bundle install`
-    }
-    `git add .`
-    `git commit -m 'initial commit'`
-    execute_bin({ "RACK_ENV" => "TEST" }, "new")
-    execute_bin({ "RACK_ENV" => "TEST" }, "setup", "--client_id", "my_client_id", "--client_secret", "my_client_secret", "--team_id", "my_team_id", "--org_name", "my_org_name")
-    VARS  = %w(client_id client_secret team_id org_name)
-    VARS.each do |var|
-      expect((`heroku config:get GITHUB_#{var.upcase}`).strip).to eql("my_#{var}")
-    end
-    # cleanup
-    appName = `heroku apps:info | grep === | cut -d " " -f 2`
-    `heroku apps:destroy --confirm #{appName}` # destroy the app
-  end
-
   it "builds the site" do
     execute_bin({}, "build")
     expect(File).to exist("#{tmp_dir}/_site/index.html")

--- a/spec/jekyll_auth_bin_spec.rb
+++ b/spec/jekyll_auth_bin_spec.rb
@@ -38,6 +38,25 @@ describe "bin" do
     expect(File).to exist("#{tmp_dir}/.env")
   end
 
+  it "sets heroku config vars" do
+    `git init`
+    `touch Gemfile`
+    Bundler.with_clean_env {
+      `bundle install`
+    }
+    `git add .`
+    `git commit -m 'initial commit'`
+    execute_bin({ "RACK_ENV" => "TEST" }, "new")
+    execute_bin({}, "setup", "--client_id", "my_client_id", "--client_secret", "my_client_secret", "--team_id", "my_team_id", "--org_name", "my_org_name")
+    VARS  = %w(client_id client_secret team_id org_name)
+    VARS.each do |var|
+      expect((`heroku config:get GITHUB_#{var.upcase}`).strip).to eql("my_#{var}")
+    end
+    # cleanup
+    appName = `heroku apps:info | grep === | cut -d " " -f 2`
+    `heroku apps:destroy --confirm #{appName}` # destroy the app
+  end
+
   it "builds the site" do
     execute_bin({}, "build")
     expect(File).to exist("#{tmp_dir}/_site/index.html")


### PR DESCRIPTION
The setup command for the CLI wasn't properly configured to accept arguments on the command line. This resulted in none of the user's settings (client id/secret, team id, org name) being pushed to their Heroku app as environment variables. The CLI should properly accept arguments now